### PR TITLE
ftp: fix for FTP growing file support

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2465,6 +2465,7 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
 
     if((instate != FTP_LIST) &&
        !data->state.prefer_ascii &&
+       !data->set.ignorecl &&
        (ftp->downloadsize < 1)) {
       /*
        * It seems directory listings either don't show the size or very

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -307,6 +307,7 @@ about to issue.
    appear at once when a file is transferred
 - `RETRNOSIZE` - Make sure the RETR response doesn't contain the size of the
   file
+- `RETRSIZE [size]` - Force RETR response to contain the specified size
 - `NOSAVE` - Don't actually save what is received
 - `SLOWDOWN` - Send FTP responses with 0.01 sec delay between each byte
 - `PASVBADIP` - makes PASV send back an illegal IP in its 227 response

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -67,7 +67,7 @@ test370 test371 test372 test373 test374 test375 test376 test378 test379 \
 test380 test381 test383 test384 test385 test386 test387 test388 test389 \
 test390 test391 test392 test393 test394 test395 test396 test397 test398 \
 test399 test400 test401 test402 test403 test404 test405 test406 test407 \
-test408 test409 test410 test411 test412 test413 test414 test415 \
+test408 test409 test410 test411 test412 test413 test414 test415 test416 \
 \
 test430 test431 test432 test433 test434 test435 test436 \
 \

--- a/tests/data/test416
+++ b/tests/data/test416
@@ -1,0 +1,51 @@
+<testcase>
+<info>
+<keywords>
+FTP
+EPSV
+RETR
+Range
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+0123456789abcdef0123456789abcdef0123456789abcdef
+</data>
+<datacheck>
+0123456789abcdef0123456789abcdef0123456789abcdef
+</datacheck>
+<servercmd>
+RETRSIZE 7
+</servercmd>
+<size>
+8
+</size>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+ <name>
+FTP growing file support
+ </name>
+ <command>
+--ignore-content-length ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+TYPE I
+RETR %TESTNUMBER
+QUIT
+</protocol>
+</verify>
+</testcase>

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -141,6 +141,7 @@ my $ctrldelay;     # set if server should throttle ctrl stream
 my $datadelay;     # set if server should throttle data stream
 my $retrweirdo;    # set if ftp server should use RETRWEIRDO
 my $retrnosize;    # set if ftp server should use RETRNOSIZE
+my $retrsize;      # set if ftp server should use RETRSIZE
 my $pasvbadip;     # set if ftp server should use PASVBADIP
 my $nosave;        # set if ftp server should not save uploaded data
 my $nodataconn;    # set if ftp srvr doesn't establish or accepts data channel
@@ -2343,6 +2344,9 @@ sub RETR_ftp {
             if($retrnosize) {
                 $sz = "size?";
             }
+            elsif($retrsize > 0) {
+                $sz = "($retrsize bytes)";
+            }
 
             sendcontrol "150 Binary data connection for $testno () $sz.\r\n";
 
@@ -2795,6 +2799,7 @@ sub customize {
     $datadelay = 0;     # default is no throttling of the data stream
     $retrweirdo = 0;    # default is no use of RETRWEIRDO
     $retrnosize = 0;    # default is no use of RETRNOSIZE
+    $retrsize = 0;      # default is no use of RETRSIZE
     $pasvbadip = 0;     # default is no use of PASVBADIP
     $nosave = 0;        # default is to actually save uploaded data to file
     $nodataconn = 0;    # default is to establish or accept data channel
@@ -2861,6 +2866,10 @@ sub customize {
         elsif($_ =~ /RETRNOSIZE/) {
             logmsg "FTPD: instructed to use RETRNOSIZE\n";
             $retrnosize=1;
+        }
+        elsif($_ =~ /RETRSIZE (\d+)/) {
+            $retrsize= $1;
+            logmsg "FTPD: instructed to use RETRSIZE = $1\n";
         }
         elsif($_ =~ /PASVBADIP/) {
             logmsg "FTPD: instructed to use PASVBADIP\n";


### PR DESCRIPTION
When using the option CURLOPT_IGNORE_CONTENT_LENGTH (set.ignorecl in code) to support growing files in FTP, the code should ignore the initial size it gets from the server as this will not be the final size of the file. This is done in ftp_state_quote() to prevent a size request being issued in the initial sequence. However, in a later call to ftp_state_get_resp() the code attempts to get the size of the content again if it doesn't already have it, by parsing the response from the RETR request. This fix prevents this parsing of the response to get the size when the set.ignorecl option is set. This should maintain the size value as -1, unknown, in this situation.